### PR TITLE
Fix image keys when image URLs contain query params

### DIFF
--- a/src/loader/AtlasLoader.js
+++ b/src/loader/AtlasLoader.js
@@ -14,6 +14,11 @@ export function atlasLoader(key, libraryJson, textureUrls, overwrite) {
     textureUrls.forEach(url => {
         const extension = url.substring(url.lastIndexOf("."));
         const file = url.substring(url.lastIndexOf("/") + 1);
+        let fileForKey = file
+
+        // If the image URL contains any query params, strip them from the filename used in the image key
+        if (file.indexOf('?') > -1) fileForKey = file.split('?')[0]
+
         this.addToFileList("image", `${key}/${file}`, url, undefined, overwrite, extension);
     });
     this.addToFileList("json", key, libraryJson, undefined, overwrite, ".json");


### PR DESCRIPTION
If an image URL contained a query param, those params would end up in the key used for the Phaser image cache.

This resulted in cache misses, because the plugin doesn't expect these query params.

This PR fixes the issue, by stripping any query params when composing the image key.

#### Before

image URL: `https://example.com/my/flump/image.png?foo=bar`
image cache key: `image/image.png?foo=bar`

Errors with `Uncaught Error: Cannot find image 'image/image.png' in game cache.`

#### After

image URL: `https://example.com/my/flump/image.png?foo=bar`
image cache key: `image/image.png`

No errors.

